### PR TITLE
CI failing because of the wrong Swift file name

### DIFF
--- a/make-ios.js
+++ b/make-ios.js
@@ -12,7 +12,7 @@ const lsp3ABI = JSON.parse(lsp3Account).abi;
 const universalReceiverABI = JSON.parse(universalReceiver).abi;
 const keyManagerABI = JSON.parse(keyManager).abi;
 
-let upSwiftFile = './ios/upcontracts.swift';
+let upSwiftFile = './ios/UpContractAbi.swift';
 
 let fileContents = 
 `


### PR DESCRIPTION
File name should be changed in `make-ios.js` because in the workflow it is correct.